### PR TITLE
Clears the console only when output is a TTY.

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -50,7 +50,7 @@ function runServer(port) {
     if (err) { return console.log(chalk.red(err)); }
 
     // clear the console
-    process.stdout.write('\x1B[2J\x1B[3J\x1B[H');
+    if (process.stdout.isTTY) process.stdout.write('\x1B[2J\x1B[3J\x1B[H');
 
     console.log();
     console.log('Starting the', chalk.green(`${process.env.NODE_ENV}`), 'server on port', chalk.green(port));


### PR DESCRIPTION
Weird stuff happens when the control characters are in the output no
matter what, for example, tailing server logs results in a cleared
console. Only clearing when in a TTY keeps those control characters out
of logfiles.