### PR TITLE
Would not run in included project without this change.

### DIFF
--- a/config/webpackDevServer.config.js
+++ b/config/webpackDevServer.config.js
@@ -41,5 +41,5 @@ module.exports = Object.assign({},
       colors: true,
     },
   },
-  appDevServerConfig,
+  appDevServerConfig
 );


### PR DESCRIPTION
When I included this version of `itg-react-scripts` in my project (site 2.0). Then:
- [x] `rm -rf node_modules`
- [x] `npm i`
- [x] `npm start`
- [x] I get the following error:
```
> adorable-site-2.0@0.0.1 start /Users/jim/code/adorable-site-2.0
> itg-react-scripts start

/Users/jim/code/adorable-site-2.0/node_modules/itg-react-scripts/config/webpackDevServer.config.js:45
);
^
SyntaxError: Unexpected token )
```