### PR TITLE
Update babel-loader to v7.1.2 to silence warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -466,13 +466,41 @@
       }
     },
     "babel-loader": {
-      "version": "7.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.0.0-alpha.3.tgz",
-      "integrity": "sha1-C/t1kSeQ6A97xCqvONY/zX8QGv8=",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.2.tgz",
+      "integrity": "sha512-jRwlFbINAeyDStqK6Dd5YuY0k5YuzQUvlz2ZamuXrXmxav3pNqe9vfJ402+2G+OmlJSXxCOpB6Uz0INM7RQe2A==",
       "requires": {
-        "find-cache-dir": "0.1.1",
+        "find-cache-dir": "1.0.0",
         "loader-utils": "1.1.0",
         "mkdirp": "0.5.1"
+      },
+      "dependencies": {
+        "find-cache-dir": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+          "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+          "requires": {
+            "commondir": "1.0.1",
+            "make-dir": "1.0.0",
+            "pkg-dir": "2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "requires": {
+            "find-up": "2.1.0"
+          }
+        }
       }
     },
     "babel-messages": {
@@ -4437,6 +4465,14 @@
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
       "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI="
+    },
+    "make-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
+      "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
+      "requires": {
+        "pify": "2.3.0"
+      }
     },
     "map-obj": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "babel-core": "^6.24.1",
-    "babel-loader": "7.0.0-alpha.3",
+    "babel-loader": "^7.1.2",
     "babel-plugin-dynamic-import-node": "^1.0.1",
     "babel-plugin-syntax-object-rest-spread": "^6.13.0",
     "babel-plugin-transform-class-properties": "^6.24.1",


### PR DESCRIPTION
🚧 

This is an attempt to silence this error in `adorableio/adorable-web`. `babel-loader@7.0.0-alpha.3 requires a peer of webpack@2 but none was installed.`

It changed the error but did not remove it: `babel-loader@7.1.2 requires a peer of webpack@2 || 3 but none was installed.`



