### PR TITLE
Replaces source map to allow cross-origin handling

### DIFF
--- a/config/webpack.development.js
+++ b/config/webpack.development.js
@@ -27,7 +27,7 @@ const env = getClientEnvironment(publicUrl);
 const PORT = parseInt(process.env.PORT, 10) || 3000;
 
 module.exports = {
-  devtool: 'eval-source-map',
+  devtool: 'cheap-module-source-map',
 
   devServer: {
     contentBase: paths.appBuild,


### PR DESCRIPTION
The `eval-source-map` loader causes the React development tools to throw a cross-origin error if anything is thrown, even if the error is caug
ht and handled (or would have been). The resulting cross-origin error is thrown in place of whatever else was thrown: as a result, the error b
eing thrown is opaque because of how the browser handles cross-origin requests, and thus removes any ability to parse or handle differing erro
rs or other throwables such as `Promise`s, etc. This is because of the `eval` nature of the loader, and the fix is to use a different loader,
such as `cheap-source-map-loader`, as suggested by React [here](https://reactjs.org/docs/cross-origin-errors.html#source-maps) and as referenc
ed in this [issue](https://github.com/facebook/react/issues/10441).